### PR TITLE
Enable ** glob patterns for ignored files & directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ _cgo_export.*
 _testmain.go
 
 *.exe
+
+.DS_Store
+.idea/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 all:
-	bash -c "mkdir -p temp; cd temp && export GOPATH=`pwd`/temp && go get github.com/qiniu/checkstyle/gocheckstyle"
+	bash -c "mkdir -p temp; cd temp && export GOPATH=`pwd`/temp && go get github.com/tomcz/checkstyle/gocheckstyle"
 	temp/bin/gocheckstyle -config=.gostyle .
 	@rm -fr temp

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 go-checkstyle
 =============
-[![Build Status](https://api.travis-ci.org/qiniu/checkstyle.png?branch=master)](https://travis-ci.org/qiniu/checkstyle)
+
+Forked from https://github.com/qiniu/checkstyle to allow "\*\*" in ignore paths via https://github.com/bmatcuk/doublestar.
 
 checkstyle is a style check tool like java checkstyle. This tool inspired by [java checkstyle](https://github.com/checkstyle/checkstyle), [golint](https://github.com/golang/lint). The style refered to some points in [Go Code Review Comments](https://code.google.com/p/go-wiki/wiki/CodeReviewComments).
 
 # Install
-  go get github.com/qiniu/checkstyle/gocheckstyle
+  go get github.com/tomcz/checkstyle/gocheckstyle
 
 # Run
   gocheckstyle -config=.go_style dir1 dir2
@@ -24,7 +25,7 @@ config is json file like the following:
     "ignore":[
         "a/*",
         "b/*/c/*.go",
-	"**/*.gen.go"
+        "**/*.gen.go"
     ],
     "fatal":[
         "formated"
@@ -36,7 +37,7 @@ config is json file like the following:
 # Add to makefile
 ```
 check_go_style:
-	bash -c "mkdir -p checkstyle; cd checkstyle && export GOPATH=`pwd` && go get github.com/qiniu/checkstyle/gocheckstyle"
+	bash -c "mkdir -p checkstyle; cd checkstyle && export GOPATH=`pwd` && go get github.com/tomcz/checkstyle/gocheckstyle"
 	checkstyle/bin/gocheckstyle -config=.go_style dir1 dir2
 
 ```
@@ -44,7 +45,7 @@ check_go_style:
 # Integrate with jenkins checkstyle plugin
 excute in shell
 ```
-    mkdir -p checkstyle; cd checkstyle && export GOPATH=`pwd` && go get github.com/qiniu/checkstyle/gocheckstyle"
+    mkdir -p checkstyle; cd checkstyle && export GOPATH=`pwd` && go get github.com/tomcz/checkstyle/gocheckstyle"
     checkstyle/bin/gocheckstyle -reporter=xml -config=.go_style dir1 dir2 2>gostyle.xml
 ```
 then add postbuild checkstyle file gostyle.xml

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 go-checkstyle
 =============
 
-Forked from https://github.com/qiniu/checkstyle to allow "\*\*" in ignore paths via https://github.com/bmatcuk/doublestar.
+_Forked from https://github.com/qiniu/checkstyle to allow "\*\*" in ignore paths via https://github.com/bmatcuk/doublestar._
 
 checkstyle is a style check tool like java checkstyle. This tool inspired by [java checkstyle](https://github.com/checkstyle/checkstyle), [golint](https://github.com/golang/lint). The style refered to some points in [Go Code Review Comments](https://code.google.com/p/go-wiki/wiki/CodeReviewComments).
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ config is json file like the following:
     "camel_name":true,
     "ignore":[
         "a/*",
-        "b/*/c/*.go"
+        "b/*/c/*.go",
+	"**/*.gen.go"
     ],
     "fatal":[
         "formated"

--- a/checkstyle.go
+++ b/checkstyle.go
@@ -195,7 +195,7 @@ func (f *file) checkFunctionParams(fType *ast.FuncType, funcName string) {
 
 	results := fType.Results
 	if results != nil {
-		if resultsNumLimit != 0 && results != nil && results.NumFields() > resultsNumLimit {
+		if resultsNumLimit != 0 && results.NumFields() > resultsNumLimit {
 			start := f.fset.Position(results.Pos())
 			problem := genResultsNumProblem(funcName, results.NumFields(), resultsNumLimit, start)
 			f.problems = append(f.problems, problem)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/tomcz/checkstyle
+
+go 1.16
+
+require github.com/bmatcuk/doublestar/v3 v3.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/bmatcuk/doublestar/v3 v3.0.0 h1:TQtVPlDnAYwcrVNB2JiGuMc++H5qzWZd9PhkNo5WyHI=
+github.com/bmatcuk/doublestar/v3 v3.0.0/go.mod h1:6PcTVMw80pCY1RVuoqu3V++99uQB3vsSYKPTd8AWA0k=

--- a/gocheckstyle/gocheckstyle.go
+++ b/gocheckstyle/gocheckstyle.go
@@ -85,7 +85,7 @@ func (p *plainReporter) Report() {
 	}
 }
 
-func (p *plainReporter) ReceiveProblems(checker checkstyle.Checker, file string, problems []checkstyle.Problem) {
+func (p *plainReporter) ReceiveProblems(checker checkstyle.Checker, _ string, problems []checkstyle.Problem) {
 	for i, problem := range problems {
 		if checker.IsFatal(&problem) {
 			p.fatalProblems = append(p.fatalProblems, &problems[i])
@@ -127,7 +127,7 @@ func (x *xmlReporter) Report() {
 	}
 }
 
-func (x *xmlReporter) ReceiveProblems(checker checkstyle.Checker, file string, problems []checkstyle.Problem) {
+func (x *xmlReporter) ReceiveProblems(_ checkstyle.Checker, file string, problems []checkstyle.Problem) {
 	if len(problems) == 0 {
 		return
 	}
@@ -156,7 +156,7 @@ func main() {
 	}
 	err = json.Unmarshal(conf, &ignore)
 	if err != nil {
-		log.Fatalf("Parse config %v fail \n", *config, err)
+		log.Fatalf("Parse config %v fail %v\n", *config, err)
 	}
 	checker, err = checkstyle.New(conf)
 	if err != nil {

--- a/gocheckstyle/gocheckstyle.go
+++ b/gocheckstyle/gocheckstyle.go
@@ -10,9 +10,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/bmatcuk/doublestar"
+	"github.com/bmatcuk/doublestar/v3"
 
-	"github.com/qiniu/checkstyle"
+	"github.com/tomcz/checkstyle"
 )
 
 const defaultConfig = `{

--- a/gocheckstyle/gocheckstyle.go
+++ b/gocheckstyle/gocheckstyle.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/bmatcuk/doublestar"
+
 	"github.com/qiniu/checkstyle"
 )
 
@@ -195,7 +197,7 @@ func checkFile(fileName string) {
 
 func isIgnoreFile(fileName string) bool {
 	for _, v := range ignore.Files {
-		if ok, _ := filepath.Match(v, fileName); ok {
+		if ok, _ := doublestar.Match(v, fileName); ok {
 			return true
 		}
 	}
@@ -204,7 +206,7 @@ func isIgnoreFile(fileName string) bool {
 
 func isIgnoreDir(dir string) bool {
 	for _, v := range ignore.Files {
-		if ok, _ := filepath.Match(v, dir); ok {
+		if ok, _ := doublestar.Match(v, dir); ok {
 			return true
 		}
 	}


### PR DESCRIPTION
This is a great tool, but it keeps on alerting on generated code that I don't have control over, and therefore I cannot use it to break the build without manual review. This PR uses a drop-in replacement for `filepath.Match` that supports the doublestar file glob so that we can ignore deeply nested & generated files & directories.